### PR TITLE
Add MIT License and Update README with Framework Documentation

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,19 @@
+The MIT License (MIT)
+Copyright © 2025 Alastair Dawson
+
+Permission is hereby granted, free of charge, to any person obtaining a copy 
+of this software and associated documentation files (the “Software”), to deal 
+in the Software without restriction, including without limitation the rights 
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell 
+copies of the Software, and to permit persons to whom the Software is furnished 
+to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all 
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, 
+INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A 
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT 
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION 
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE 
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,49 +1,135 @@
 # Swallow Framework
 
-A lightweight Python framework designed for simplicity and speed.
+A lightweight, reactive Model-View-Command-Context (MVCC) framework for building 
+structured applications with event-driven architecture.
+
+## Overview
+
+Swallow Framework provides a modern approach to application architecture by combining
+the best aspects of MVC with reactive state management and the command pattern. It's 
+designed to create maintainable, testable applications with clear separation of concerns.
+
+### Key Features
+
+- **Model-View-Command-Context Pattern**: A structured approach to application architecture
+- **Reactive State Management**: Observable properties with automatic change detection and notification
+- **Event-Driven Communication**: Components communicate through events rather than direct references
+- **Command Pattern Implementation**: Actions encapsulated as commands for better testability
+- **Lightweight and Flexible**: Minimal dependencies and adaptable to different application types
+
+## Architecture
+
+Swallow Framework is built on four main components:
+
+### Model
+
+Models manage application state using reactive properties. Any changes to these properties 
+automatically notify registered listeners.
+
+```python
+from swallow_framework.mvcc.model import Model
+from swallow_framework.state.property import state
+
+class UserModel(Model):
+    name = state("")
+    age = state(0)
+    
+    def update_user(self, name, age):
+        self.name = name
+        self.age = age
+
+# Listen for changes
+user = UserModel()
+user.on_change('name', lambda value: print(f"Name changed to: {value}"))
+```
+
+### View
+
+Views handle user interaction and dispatch events through the context.
+
+```python
+from swallow_framework.mvcc.view import View
+from swallow_framework.core.events import Event
+
+class UserFormView(View):
+    def submit_form(self, name, age):
+        self.dispatch(Event("update_user", {"name": name, "age": age}))
+```
+
+### Command
+
+Commands encapsulate actions to be performed on models.
+
+```python
+from swallow_framework.mvcc.command import Command
+
+class UpdateUserCommand(Command):
+    def execute(self, data):
+        self.model.update_user(data["name"], data["age"])
+```
+
+### Context
+
+The context maps events to commands and facilitates event dispatching.
+
+```python
+from swallow_framework.mvcc.context import Context
+from swallow_framework.core.events import EventDispatcher
+
+class AppContext(Context):
+    def __init__(self):
+        super().__init__(EventDispatcher())
+        
+        # Map events to commands
+        user_model = UserModel()
+        self.map_command("update_user", UpdateUserCommand(user_model))
+```
 
 ## Installation
 
-You can install the Swallow Framework using `uv`:
-
 ```bash
-uv pip install swallow-framework
+pip install git+https://github.com/rocket-tycoon/swallow-framework.git
 ```
 
-Or using pip:
+You can also clone the repository and install it locally:
 
 ```bash
-pip install swallow-framework
-```
-
-## Quick Start
-
-- TBD
-
-## Features
-
-- TBD
-
-## Development
-
-### Setup Development Environment
-
-```bash
-# Clone the repository
-git clone https://github.com/yourusername/swallow-framework.git
+git clone https://github.com/rocket-tycoon/swallow-framework.git
 cd swallow-framework
-
-# Create a virtual environment and install dependencies
-uv venv .venv
-source .venv/bin/activate  # On Windows: .venv\Scripts\activate
-uv pip install -e ".[dev]"
+pip install -e .
 ```
 
-### Running Tests
+## Getting Started
 
-```bash
-pytest
+1. Create your models with reactive state properties
+2. Define commands to encapsulate actions on models
+3. Create a context that maps events to commands
+4. Build views that dispatch events through the context
+
+```python
+# Create the application context
+context = AppContext()
+
+# Create a view with the context
+view = UserFormView(context)
+
+# Handle user interactions
+view.submit_form("Alice", 30)
 ```
+
+## Examples
+
+Check the `examples/` directory for complete application examples using the Swallow Framework.
+
+## Contributing
+
+Contributions are welcome! Please feel free to submit a Pull Request.
+
+1. Fork the repository
+2. Create your feature branch (`git checkout -b feature/amazing-feature`)
+3. Commit your changes (`git commit -m 'Add some amazing feature'`)
+4. Push to the branch (`git push origin feature/amazing-feature`)
+5. Open a Pull Request
 
 ## License
 


### PR DESCRIPTION
## Add MIT License and Update README with Framework Documentation

### Description:

This pull request introduces two significant updates to the repository:

1. **Added the MIT License**:  
   The project is now licensed under the MIT License, which provides users with the freedom to use, modify, distribute, and sublicense the software while establishing clear limitations and disclaimers of liability.

2. **Enhanced README Documentation**:  
   - Detailed description of the Swallow Framework, including its architecture and design principles.  
   - Explanation of the Model-View-Command-Context (MVCC) pattern and its components (Model, View, Command, Context).  
   - Code examples demonstrating how to implement and use the framework effectively.  
   - Improved installation instructions, example workflows, and guidelines for contributing to the project.  

These changes aim to make the project more accessible to developers by providing clear licensing terms and comprehensive documentation, fostering easier adoption and contribution.

### Changes:  
- Added a `LICENSE.md` file with the MIT License.  
- Significantly expanded the content of the `README.md` file with usage details, examples, and contribution guidelines.

### Testing:  
No functional code changes were made, so no additional tests are required for this PR.