### PR TITLE
Fix: Correct package structure for proper installation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,12 +25,13 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install pytest pytest-cov
-        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-        pip install -e .
+        pip install -e .  # Ensure package is installed correctly
 
     - name: Run tests with pytest
       run: |
-        pytest tests/ --cov=src/swallow_framework --cov-report=xml
+        PYTHONPATH=src pytest tests/ --cov=src/swallow_framework --cov-report=xml
+      env:
+        PYTHONPATH: src  # Set PYTHONPATH to src to avoid import issues
 
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,7 @@ testpaths = ["tests"]
 python_files = "test_*.py"
 
 [tool.hatch.build.targets.wheel]
-packages = ["src/swallow_framework"]  # Specify the package source directory
+packages = ["swallow_framework"]
 
-[tool.hatch.build.targets.wheel.sources."."]
-path = "src"  # Where the sources are found
+[tool.hatch.build.hooks.module]
+used-packages = ["swallow_framework"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,10 +17,14 @@ classifiers = [
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
 ]
 dependencies = [
+    "prompt_toolkit",
+    "pyperclip"
     # Add your dependencies here
 ]
 
@@ -39,7 +43,7 @@ dev = [
 
 [tool.black]
 line-length = 88
-target-version = ["py38", "py39", "py310"]
+target-version = ["py38", "py39", "py310", "py311", "py312"]
 
 [tool.isort]
 profile = "black"
@@ -55,3 +59,9 @@ disallow_incomplete_defs = true
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 python_files = "test_*.py"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/swallow_framework"]  # Specify the package source directory
+
+[tool.hatch.build.targets.wheel.sources."."]
+path = "src"  # Where the sources are found

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,9 +8,9 @@ version = "0.1.0"
 description = "A lightweight Python framework"
 readme = "README.md"
 requires-python = ">=3.8"
-license = {text = "MIT"}
+license = { text = "MIT" }
 authors = [
-    {name = "Alastair Dawson", email = "alastair.j.dawson@gmail.com"},
+    { name = "Alastair Dawson", email = "alastair.j.dawson@gmail.com" },
 ]
 classifiers = [
     "Programming Language :: Python :: 3",
@@ -21,11 +21,6 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
-]
-dependencies = [
-    "prompt_toolkit",
-    "pyperclip"
-    # Add your dependencies here
 ]
 
 [project.urls]
@@ -59,9 +54,7 @@ disallow_incomplete_defs = true
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 python_files = "test_*.py"
+addopts = "--strict-markers"
 
 [tool.hatch.build.targets.wheel]
 packages = ["swallow_framework"]
-
-[tool.hatch.build.hooks.module]
-used-packages = ["swallow_framework"]


### PR DESCRIPTION
## Description
This PR addresses an issue where the `swallow-framework` package was not being installed with the correct structure, leading to `ModuleNotFoundError` during imports. The `pyproject.toml` file has been updated to explicitly specify the package source directory (`src/swallow_framework`) for Hatchling, ensuring that the `src` directory is included in the installed package. This resolves import errors and allows applications to correctly import modules from the `swallow-framework`. Rebuild and reinstall the package after applying this fix.

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update

## How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes -->
- [ ] Unit tests added/updated
- [ ] All existing tests pass